### PR TITLE
Use RSYSLOG_ForwardFormat on clients

### DIFF
--- a/templates/central_syslog.conf.j2
+++ b/templates/central_syslog.conf.j2
@@ -1,15 +1,13 @@
 ## {{ ansible_managed }}
 {% if not central_log_listener %}
-# LogFmt sets a better timestamp
-$template LogFmt,"%timereported:::date-rfc3339% %hostname% %syslogseverity-text% %syslogtag% %msg:::drop-last-lf%\n"
 ## Log some stuff to central log hosts. TCP/UDP is controlled by hostname.
 ## @ for UDP and @@ for TCP
-authpriv.*                                      {{ central_log_host }};LogFmt
-local0.*                                        {{ central_log_host }};LogFmt
-*.err                                           {{ central_log_host }};LogFmt
+authpriv.*                                      {{ central_log_host }};RSYSLOG_ForwardFormat
+local0.*                                        {{ central_log_host }};RSYSLOG_ForwardFormat
+*.err                                           {{ central_log_host }};RSYSLOG_ForwardFormat
 
 {% for program in central_log_ship_these_programs %}
-if $programname startswith '{{ program }}' then {{ central_log_host }};LogFmt
+if $programname startswith '{{ program }}' then {{ central_log_host }};RSYSLOG_ForwardFormat
 {% endfor %}
 
 
@@ -27,7 +25,7 @@ $ModLoad imtcp
 $InputTCPServerRun 514
 
 $Template GENERALTEMPLATE,"{{ central_logs_directory }}/%hostname%.log"
-$template LogFmt,"%timereported:::date-rfc3339% %hostname% %syslogseverity-text% %syslogtag% %msg:::drop-last-lf%\n"
+$template LogFmt,"%timereported:::date-rfc3339% %hostname% %syslogseverity-text% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
 
 if $fromhost-ip startswith '10.' then { 
 	?GENERALTEMPLATE;LogFmt


### PR DESCRIPTION
Otherwise it seems the servers misparses the messages somehow and the severity is printed twice in the log files. RSYSLOG_ForwardFormat is a builtin format which is the recommended format when forwarding to a rsyslog server.
