### PR TITLE
Allow remote logs to be filed per function instead of per host

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ central_log_listener: False
 central_logs_directory: "/var/log/remote/servers"
 central_logs_retention_days: 30
 central_log_maxopenfiles: 100000
+central_log_by_function: False
 
 # central_log_ship_these_programs is used in a jinja2
 # for loop that creates rsyslog rules like:

--- a/templates/central_syslog.conf.j2
+++ b/templates/central_syslog.conf.j2
@@ -26,11 +26,22 @@ $InputTCPServerRun 514
 
 $MaxOpenFiles {{ central_log_maxopenfiles }}
 
+{% if central_log_by_function %}
+if $fromhost-ip startswith '10.' then {
+	*.info;mail.none;authpriv.none;cron.none {{ central_logs_directory }}/messages;RSYSLOG_FileFormat
+	authpriv.* {{ central_logs_directory }}/secure;RSYSLOG_FileFormat
+	mail.* {{ central_logs_directory }}/maillog;RSYSLOG_FileFormat
+	cron.* {{ central_logs_directory }}/cron;RSYSLOG_FileFormat
+	stop
+}
+
+{% else %}
 $Template GENERALTEMPLATE,"{{ central_logs_directory }}/%hostname%.log"
 $template LogFmt,"%timereported:::date-rfc3339% %hostname% %syslogseverity-text% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
 
-if $fromhost-ip startswith '10.' then { 
+if $fromhost-ip startswith '10.' then {
 	?GENERALTEMPLATE;LogFmt
 	stop
 }
+{% endif %}
 {% endif %}


### PR DESCRIPTION
By setting central_log_by_function to True, logs collected by the
daemon will be stored in files per function instead of per host.
