### PR TITLE
Also rotate per-function logs

### DIFF
--- a/templates/remote_logrotate.j2
+++ b/templates/remote_logrotate.j2
@@ -1,6 +1,11 @@
 # {{ ansible_managed }}
 
-{{ central_logs_directory }}/*.log {
+{{ central_logs_directory }}/messages
+{{ central_logs_directory }}/secure
+{{ central_logs_directory }}/cron
+{{ central_logs_directory }}/maillog
+{{ central_logs_directory }}/*.log
+{
     daily
     rotate {{ central_logs_retention_days }}
     compress


### PR DESCRIPTION
Match more log files to rotate, which is needed if central_log_by_function is set to True.
