### PR TITLE
option to add secondary loghost

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ central_log_extra_settings:
  - "$ActionQueueType LinkedList"
 </pre>
 
+There is also option to setup secondary log host for forwarding. See defauls/main.yml for params.
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,4 +29,12 @@ central_log_ship_these_programs:
 #- "$ActionQueueSize 1000000"
 #- "$ActionQueueDequeueBatchSize 500000"
 #- "$ActionQueueType LinkedList"
-#
+
+# secondary loghost can be defined if setting e.g.
+#secondary_log_host: '@@192.168.1.1:514'
+#secondary_rsyslog_conf_file: 'secondary_log_host.conf'
+#secondary_log_rules:
+#  - "*.debug"
+#secondary_log_extra_settings:
+#  - "$PreserveFQDN on"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,11 @@
   template: src=central_syslog.conf.j2 dest={{ syslog_conf_path }}/{{ central_conf_file }} owner=root group=root mode=0644 backup=yes
   notify: Restart rsyslog
 
+- name: template secondaray rsyslog config
+  template: src=secondary_syslog.conf.j2 dest={{ syslog_conf_path }}/{{ secondary_rsyslog_conf_file }} owner=root group=root mode=0644 backup=no
+  notify: Restart rsyslog
+  when: secondary_log_host is defined
+
 - name: Create location of remote logs on the central_log_listener
   file: path={{ central_logs_directory }} state=directory owner=root group=root mode=0755
   when: central_log_listener|bool

--- a/templates/secondary_syslog.conf.j2
+++ b/templates/secondary_syslog.conf.j2
@@ -1,0 +1,14 @@
+## {{ ansible_managed }}
+
+{% if secondary_log_extra_settings is defined %}
+{% for log_setting in secondary_log_extra_settings %}
+{{ log_setting }}
+{% endfor %}
+{% endif %}
+
+{% if secondary_log_rules is defined %}
+{% for rule in secondary_log_rules %}
+{{ rule }}          {{ secondary_log_host }};RSYSLOG_ForwardFormat
+{% endfor %}
+{% endif %}
+


### PR DESCRIPTION
Would be important for certain servers to push logs to siem service etc. This allows settings these along with previous configurations.